### PR TITLE
Fix GogoAnime API

### DIFF
--- a/app/src/main/java/com/example/animat/api/API.kt
+++ b/app/src/main/java/com/example/animat/api/API.kt
@@ -3,7 +3,7 @@ package com.example.animat.api
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-const val URL_BASE = "https://gogoanime.consumet.stream/"
+const val URL_BASE = "https://api.consumet.org/anime/gogoanime/"
 
 class API {
     fun createAPIService(): ApiInterface {

--- a/app/src/main/java/com/example/animat/models/Anime.kt
+++ b/app/src/main/java/com/example/animat/models/Anime.kt
@@ -1,0 +1,9 @@
+package com.example.animat.models
+
+data class Anime(
+    val id: String,
+    val title: String,
+    val image: String,
+    val url: String,
+    val genres: ArrayList<String>
+)

--- a/app/src/main/java/com/example/animat/models/Animes.kt
+++ b/app/src/main/java/com/example/animat/models/Animes.kt
@@ -1,5 +1,7 @@
 package com.example.animat.models
 
 data class Animes(
-    val animeList: List<Anime>
+    val currentPage: Int,
+    val hasNextPage: Boolean,
+    val results: List<Anime>
 )


### PR DESCRIPTION
Ahora vamos a utilizar una [versión nueva](https://docs.consumet.org/rest-api/Anime/gogoanime/get-top-airing-anime) de la API, ya que el URL anterior está caído. También olvidamos agregar el modelo Anime en el commit anterior y lo estamos adecuando a los atributos actualizados del URL nuevo.